### PR TITLE
Models Date.Now Fix

### DIFF
--- a/src/interfaces/campaign.interface.ts
+++ b/src/interfaces/campaign.interface.ts
@@ -7,8 +7,8 @@ export interface ICampaign {
 	description: string;
 	playersNeeded: number;
 	currentPlayers: Types.ObjectId[];
-	createdAt?: number;
-	updatedAt?: number;
+	createdAt?: Date;
+	updatedAt?: Date;
 	deleted: boolean;
 	img: string;
 }

--- a/src/interfaces/comment.interface.ts
+++ b/src/interfaces/comment.interface.ts
@@ -6,7 +6,7 @@ export interface IComment {
 	postRef?: Types.ObjectId;
 	creator: Types.ObjectId;
 	content: string;
-	createdAt?: number;
-	updatedAt?: number;
+	createdAt?: Date;
+	updatedAt?: Date;
 	deleted: boolean;
 }

--- a/src/interfaces/join-campaign-request.interface.ts
+++ b/src/interfaces/join-campaign-request.interface.ts
@@ -7,6 +7,6 @@ export interface IJoinCampaignRequest extends Document {
 	campaign: ICampaign['_id'];
 	isSentByCreator: boolean;
 	status: 'pending' | 'accepted' | 'rejected';
-	createdAt?: number;
-	updatedAt?: number;
+	createdAt?: Date;
+	updatedAt?: Date;
 }

--- a/src/models/campaign.model.ts
+++ b/src/models/campaign.model.ts
@@ -18,11 +18,11 @@ const CampaignSchema = new Schema<ICampaign>(
 		},
 		createdAt: {
 			type: Date,
-			default: Date.now(),
+			default: Date.now,
 		},
 		updatedAt: {
 			type: Date,
-			default: Date.now(),
+			default: Date.now,
 		},
 		title: {
 			type: String,

--- a/src/models/character.model.ts
+++ b/src/models/character.model.ts
@@ -30,11 +30,11 @@ const CharacterSchema = new Schema<ICharacter>(
 		},
 		createdAt: {
 			type: Date,
-			default: Date.now(),
+			default: Date.now,
 		},
 		updatedAt: {
 			type: Date,
-			default: Date.now(),
+			default: Date.now,
 		},
 	},
 	{ versionKey: false }

--- a/src/models/comment.model.ts
+++ b/src/models/comment.model.ts
@@ -28,11 +28,11 @@ const CommentSchema = new Schema<IComment>(
 		},
 		createdAt: {
 			type: Date,
-			default: Date.now(),
+			default: Date.now,
 		},
 		updatedAt: {
 			type: Date,
-			default: Date.now(),
+			default: Date.now,
 		},
 	},
 	{ versionKey: false }

--- a/src/models/join-campaign-request.model.ts
+++ b/src/models/join-campaign-request.model.ts
@@ -11,15 +11,15 @@ const JoinCampaignRequestSchema = new Schema<IJoinCampaignRequest>(
 			enum: ['pending', 'accepted', 'rejected'],
 			default: 'pending',
 		},
-		createdAt: { type: Number, default: Date.now },
-		updatedAt: { type: Number, default: Date.now },
+		createdAt: { type: Date, default: Date.now },
+		updatedAt: { type: Date, default: Date.now },
 	},
 	{ versionKey: false }
 );
 
 JoinCampaignRequestSchema.pre<IJoinCampaignRequest>('save', function (next) {
 	if (!this.isNew) {
-		this.updatedAt = Date.now();
+		this.updatedAt = new Date();
 	}
 	next();
 });

--- a/src/models/session.model.ts
+++ b/src/models/session.model.ts
@@ -11,11 +11,11 @@ const SessionSchema = new Schema<ISession>(
 		},
 		createdAt: {
 			type: Date,
-			default: Date.now(),
+			default: Date.now,
 		},
 		expiresAt: {
 			type: Date,
-			default: Date.now() + 1000 * 60 * 60 * 24, // 7 days
+			default: () => Date.now() + 1000 * 60 * 60 * 24 * 7, // 7 days
 		},
 		active: {
 			type: Boolean,

--- a/src/models/user.model.ts
+++ b/src/models/user.model.ts
@@ -28,11 +28,11 @@ const UserSchema = new Schema<IUser>(
 		},
 		createdAt: {
 			type: Date,
-			default: Date.now(),
+			default: Date.now,
 		},
 		updatedAt: {
 			type: Date,
-			default: Date.now(),
+			default: Date.now,
 		},
 		deleted: {
 			type: Boolean,


### PR DESCRIPTION
Changed usage of Date.time() to Date.time in mongoose schemas.

[What is the difference between Date.now() and Date.now in mongoose? - StackOverflow](https://stackoverflow.com/questions/35501273/what-is-the-difference-between-date-now-and-date-now-in-mongoose)
> If you pass Date.now as the default in your mongoose schema, you are passing the function and mongoose will call that function every time a document needs a default value for that property. This results in the current time, at the time of document creation, being stored as the value for that property.
> 
> However, if you pass Date.now() instead, you are passing the value returned by Date.now() rather than the function. By doing this, your documents will get the current time, at the time of schema creation, as the default value for that property. This means that your documents will store the time of the latest deployment, which is probably not what you want.